### PR TITLE
fix(catalog): fix 01-mean-variance sketch/description inaccuracies

### DIFF
--- a/viz_catalog/catalog.yaml
+++ b/viz_catalog/catalog.yaml
@@ -102,6 +102,27 @@ analyses:
     plots:
       # ── Broadband analyses (mean_variance_broadband.ipynb) ──────────────
 
+      - id: "zscore_rationale"
+        title: "Z-score normalization — rationale (section 0)"
+        notebook: "notebooks/01-raw-mean-variance-analysis/mean_variance_broadband.ipynb"
+        section: "Data preparation"
+        filename_pattern: "(no output plot — preprocessing step)"
+        data_shape:
+          input: "(n_subjects, n_channels, n_times) — raw broadband EEG"
+          output: "(n_subjects, n_channels, n_times) — Z-scored along time axis"
+        operation_order:
+          - "For each subject s and channel c: subtract mean_t(x_{s,c}) and divide by std_t(x_{s,c})"
+          - "scipy.stats.zscore applied along axis=2 — shape (n_subjects, n_channels, n_times) preserved"
+          - "Result: every channel of every subject has mean=0 and std=1 along time"
+          - "Removes amplitude differences between subjects and channels"
+          - "After Z-scoring: intersubject variance at each (channel, time) cell purely reflects momentary disagreement in signal shape"
+        interpretation: >
+          Z-scoring is necessary before mean-variance analysis. Without it, amplitude
+          differences between subjects dominate the variance signal and mask true
+          neural synchrony. After Z-scoring, low variance across subjects at a given
+          (channel, time) point directly indicates high inter-subject synchrony.
+        sketch_type: "zscore_transform"
+
       - id: "timeseries_overview"
         title: "Intersubject time-series overview (two-panel)"
         notebook: "notebooks/01-raw-mean-variance-analysis/mean_variance_broadband.ipynb"
@@ -111,8 +132,6 @@ analyses:
           input: "(n_subjects, n_channels, n_times) — z-scored broadband"
           output: "Top: (n_subjects, n_times) + (n_times,); Bottom: (n_times,)"
         operation_order:
-          - "mean(axis=1) → (n_subjects, n_times) per-subject channel average"
-          - "From (n_subjects, n_times): mean(axis=0) → (n_times,) group mean"
           - "From (n_subjects, n_channels, n_times): var(axis=0) → (n_channels, n_times), then mean over channels → (n_times,)"
           - "Top panel: overlay per-subject traces, group mean, ±1 SD band"
           - "Bottom panel: channel-averaged intersubject variance over time"
@@ -120,7 +139,7 @@ analyses:
           Top panel shows how individual subjects' channel-averaged signals
           relate to the group mean. Bottom panel reveals temporal fluctuations
           in intersubject variance — dips indicate moments of high synchrony.
-        sketch_type: "timeseries_variance"
+        sketch_type: "timeseries_two_panel"
 
       - id: "variance_distribution"
         title: "Intersubject variance distribution"
@@ -132,12 +151,13 @@ analyses:
           output: "histogram of all channel × time variance values"
         operation_order:
           - "Flatten (n_channels, n_times) variance array"
-          - "Clip at 99th percentile to suppress outliers"
-          - "Plot histogram with median and 99th-percentile markers"
+          - "Clip at 99th percentile — values beyond this are outliers and not displayed"
+          - "Plot histogram with median marker and 99th-percentile right-boundary marker"
         interpretation: >
-          Shows the overall distribution of intersubject variance values.
-          A heavy left tail indicates many low-variance (high-synchrony)
-          time-channel pairs.
+          Shows the distribution of intersubject variance across all channel and
+          time pairs. The 99th-percentile marker marks the right boundary — values
+          beyond it are clipped as outliers. A heavy left tail indicates many
+          low-variance (high-synchrony) time-channel pairs.
         sketch_type: "histogram"
 
       - id: "windowed_bar"
@@ -147,17 +167,19 @@ analyses:
         filename_pattern: "windowed_bar*.png"
         data_shape:
           input: "(n_subjects, n_channels, n_times) via stats dict"
-          output: "(n_windows,) per-window mean signal and mean variance"
+          output: "(n_windows,) per-window mean z-scored signal and mean variance"
         operation_order:
           - "Divide recording into overlapping windows (default 2 s, 50% overlap)"
-          - "Compute per-window mean signal and mean intersubject variance"
-          - "Label windows below the 10th-percentile variance as sync candidates"
-          - "Plot two bar charts: top = mean signal, bottom = mean variance; green = sync"
+          - "Compute per-window mean of the z-scored signal and mean intersubject variance"
+          - "Label windows below the 10th-percentile variance (lowest 10%) as sync candidates"
+          - "Top bar chart (blue): mean of the z-scored signal per window (x = time, y = mean value)"
+          - "Bottom bar chart (orange): mean variance per window; green bars mark sync-candidate windows"
         interpretation: >
-          Green bars mark windows where intersubject variance is below the
-          synchrony threshold. The top panel shows the corresponding mean
-          signal level in those windows.
-        sketch_type: "bar_grouped"
+          Green bars mark windows where intersubject variance is below the 10th-percentile
+          synchrony threshold (lowest 10% variance). The top panel shows the corresponding
+          mean z-scored signal level in those windows. Windowed statistics reduce noise at
+          the cost of fine temporal resolution.
+        sketch_type: "windowed_mean_var_bars"
 
       - id: "windowed_overlay"
         title: "Windowed synchrony — overlay with electrode heatmap"
@@ -166,16 +188,18 @@ analyses:
         filename_pattern: "windowed_overlay*.png"
         data_shape:
           input: "(n_subjects, n_channels, n_times) via stats dict + windows DataFrame"
-          output: "3-panel: continuous traces, step functions, (n_channels, n_times) heatmap"
+          output: "3-panel: mean signal trace, variance trace with windowed mean, (n_channels, n_times) heatmap"
         operation_order:
-          - "Overlay continuous group-mean signal with windowed step function"
-          - "Overlay continuous variance with windowed step function and sync threshold"
-          - "Plot per-electrode variance heatmap (channels × time) with sync spans highlighted"
+          - "Panel 1: mean signal time-series — per-subject traces overlaid with group mean (same as timeseries_overview panel 1)"
+          - "Panel 2: continuous intersubject variance (orange) overlaid with windowed mean variance step function (red)"
+          - "Panel 3: heatmap of variance per channel over time — values are positive only, reddish colormap (no blue scale)"
         interpretation: >
-          The overlay shows how the windowed approximation tracks the
-          continuous signal. The heatmap reveals which electrodes contribute
-          most to synchrony or desynchrony at each time point.
-        sketch_type: "timeseries_heatmap"
+          Panel 1 shows individual subject responses relative to the group mean.
+          Panel 2 shows how the windowed step approximation tracks the continuous variance —
+          useful for identifying synchrony episodes. The heatmap reveals which electrodes
+          drive synchrony or desynchrony at each moment. Windowed statistics reduce noise
+          at the cost of fine temporal resolution.
+        sketch_type: "windowed_overlay_panels"
 
       # ── Per-band analyses (mean_variance_bands.ipynb) ───────────────────
 
@@ -189,13 +213,14 @@ analyses:
           output: "5 bands × 2 columns: (n_times,) mean signal + (n_times,) variance per band"
         operation_order:
           - "Bandpass filter z-scored data into 5 bands (delta/theta/alpha/beta/gamma)"
-          - "compute_intersubject_stats per band"
-          - "Left column: group-mean signal with per-subject traces and ±1 SD"
+          - "compute_intersubject_stats per band → mean signal and intersubject variance"
+          - "Left column: group-mean signal with per-subject traces and ±1 SD band"
           - "Right column: channel-averaged intersubject variance with sync threshold"
         interpretation: >
           Reveals which frequency bands exhibit the strongest intersubject
           synchrony over time. Each row isolates a different oscillatory
-          component.
+          component. Band colors: delta=blue, theta=orange, alpha=green,
+          beta=red, gamma=violet.
         sketch_type: "timeseries_multiband"
 
       - id: "band_variance_distributions"
@@ -208,12 +233,14 @@ analyses:
           output: "one histogram per band (2-column grid)"
         operation_order:
           - "For each band: flatten (n_channels, n_times) variance"
-          - "Clip at 99th percentile"
-          - "Plot histogram with median marker"
+          - "Clip at 99th percentile — right boundary, values beyond are outliers"
+          - "Plot histogram with median marker and 99th-percentile right-boundary marker"
         interpretation: >
-          Compares the shape and spread of variance distributions across
-          frequency bands. Narrower, left-shifted distributions indicate
-          higher overall synchrony in that band.
+          Shows the distribution of intersubject variance across all channel and
+          time pairs for each frequency band. The 99th-percentile marker is the
+          right boundary; values beyond it are clipped as outliers. Compares
+          the shape and spread across bands — narrower, left-shifted distributions
+          indicate higher overall synchrony in that band.
         sketch_type: "histogram_facet"
 
       - id: "isc_matrices"
@@ -247,15 +274,16 @@ analyses:
           output: "(n_windows,) per band — bar charts, summary, and per-band detailed figures"
         operation_order:
           - "For each band: divide into overlapping windows (default 2 s, 50% overlap)"
-          - "Compute per-window mean variance; label sync candidates (< 10th pct)"
-          - "Bar figure: all bands in multi-row bar chart"
+          - "Compute per-window mean of the z-scored signal and mean variance; label sync candidates (variance < 10th pct)"
+          - "Bar figure: multi-row bar chart — top row per band = mean signal (band color), bottom row = variance (band color, green = sync)"
           - "Summary figure: windowed variance with sync spans highlighted per band"
-          - "Per-band figures: continuous variance, step function, threshold, electrode heatmap"
+          - "Per-band overlay figure (3 panels per band): mean signal trace, continuous variance (band color) + windowed mean line (red), channel variance heatmap (reddish colormap, positive only)"
         interpretation: >
-          Shows time-resolved synchrony detection independently per frequency
-          band. The summary figure enables quick cross-band comparison of
-          where synchrony episodes occur, while individual per-band figures
-          add electrode-level detail.
+          Shows time-resolved synchrony detection independently per frequency band.
+          Band colors: delta=blue, theta=orange, alpha=green, beta=red, gamma=violet.
+          The summary figure enables quick cross-band comparison of where synchrony
+          episodes occur. Per-band overlay figures add electrode-level detail.
+          Windowed statistics reduce noise at the cost of fine temporal resolution.
         sketch_type: "grid_timeseries_heatmap"
 
   - id: "02-isc-broadband"

--- a/viz_catalog/pages/1_📋_Catalog.py
+++ b/viz_catalog/pages/1_📋_Catalog.py
@@ -179,12 +179,15 @@ def sketch_histogram() -> Figure:
     rng = np.random.default_rng(6)
     fig, ax = plt.subplots(figsize=(4, 2.5))
     data = rng.gamma(2, 0.3, 400)
-    ax.hist(data, bins=30, color="steelblue", edgecolor="white", lw=0.4)
-    threshold = np.percentile(data, 10)
-    ax.axvline(threshold, color="tomato", ls="--", lw=1, label="10th pct")
-    ax.set_xlabel("Window variance", fontsize=7)
+    clip99 = np.percentile(data, 99)
+    data_clipped = data[data <= clip99]
+    ax.hist(data_clipped, bins=30, color="darkorange", edgecolor="white", lw=0.4)
+    median = np.median(data_clipped)
+    ax.axvline(median, color="steelblue", ls="-", lw=1.2, label="median")
+    ax.axvline(clip99, color="tomato", ls="--", lw=1, label="99th pct")
+    ax.set_xlabel("Intersubject variance", fontsize=7)
     ax.set_ylabel("Count", fontsize=7)
-    ax.set_title("Windowed variance distribution", fontsize=8)
+    ax.set_title("Variance distribution (channel × time)", fontsize=8)
     ax.legend(fontsize=6)
     ax.tick_params(labelsize=6)
     fig.tight_layout()
@@ -211,18 +214,35 @@ def sketch_timeseries_multisubject() -> Figure:
 
 def sketch_timeseries_multiband() -> Figure:
     rng = np.random.default_rng(8)
-    bands = ["δ", "θ", "α", "β", "γ"]
-    colors = ["#4C72B0", "#55A868", "#C44E52", "#8172B2", "#CCB974"]
+    bands = ["delta", "theta", "alpha", "beta", "gamma"]
+    colors = ["steelblue", "darkorange", "seagreen", "tomato", "mediumpurple"]
     t = np.linspace(0, 8, 300)
-    fig, axes = plt.subplots(5, 1, figsize=(5, 3.5), sharex=True)
-    for ax, band, col in zip(axes, bands, colors):
-        y = np.abs(rng.standard_normal(300)) * 0.4 + 0.4
-        ax.plot(t, y, lw=0.8, color=col)
-        ax.set_ylabel(band, fontsize=7, rotation=0, labelpad=14)
-        ax.tick_params(labelsize=5)
-        ax.set_yticks([])
-    axes[-1].set_xlabel("Time (s)", fontsize=7)
-    axes[0].set_title("Per-band variance traces", fontsize=8)
+    fig, axes = plt.subplots(5, 2, figsize=(5.5, 3.5), sharex=True)
+    for row, (band, col) in enumerate(zip(bands, colors)):
+        # Left: mean signal
+        n_subj = 4
+        mean_y = rng.standard_normal(300) * 0.3
+        ax_l = axes[row, 0]
+        for _ in range(n_subj):
+            ax_l.plot(
+                t, mean_y + rng.standard_normal(300) * 0.1, lw=0.5, alpha=0.4, color=col
+            )
+        ax_l.plot(t, mean_y, lw=0.9, color=col)
+        ax_l.set_ylabel(band, fontsize=6, rotation=0, labelpad=28)
+        ax_l.tick_params(labelsize=4)
+        ax_l.set_yticks([])
+        # Right: variance
+        var_y = np.abs(rng.standard_normal(300)) * 0.4 + 0.4
+        threshold = np.percentile(var_y, 10)
+        ax_r = axes[row, 1]
+        ax_r.plot(t, var_y, lw=0.8, color=col)
+        ax_r.axhline(threshold, color="gray", ls="--", lw=0.6)
+        ax_r.tick_params(labelsize=4)
+        ax_r.set_yticks([])
+    axes[-1, 0].set_xlabel("Time (s)", fontsize=6)
+    axes[-1, 1].set_xlabel("Time (s)", fontsize=6)
+    axes[0, 0].set_title("Mean signal", fontsize=7)
+    axes[0, 1].set_title("Variance", fontsize=7)
     fig.tight_layout()
     return fig
 
@@ -304,27 +324,29 @@ def sketch_bar_grouped() -> Figure:
 
 def sketch_histogram_facet() -> Figure:
     rng = np.random.default_rng(12)
-    bands = ["δ", "θ", "α", "β", "γ"]
-    colors = ["#4C72B0", "#55A868", "#C44E52", "#8172B2", "#CCB974"]
+    bands = ["delta", "theta", "alpha", "beta", "gamma"]
+    colors = ["steelblue", "darkorange", "seagreen", "tomato", "mediumpurple"]
     fig, axes = plt.subplots(1, 5, figsize=(6, 2.2), sharey=True)
     for ax, band, col in zip(axes, bands, colors):
-        d = rng.normal(0.1 + rng.uniform(-0.05, 0.1), 0.1, 200)
-        ax.hist(
-            d, bins=15, color=col, edgecolor="white", lw=0.3, orientation="vertical"
-        )
-        ax.axvline(0, color="gray", ls="--", lw=0.6)
-        ax.set_title(band, fontsize=7)
-        ax.tick_params(labelsize=5)
-        ax.set_xlabel("r", fontsize=6)
+        d = rng.gamma(2, 0.3, 200)
+        clip99 = np.percentile(d, 99)
+        d_clipped = d[d <= clip99]
+        ax.hist(d_clipped, bins=15, color=col, edgecolor="white", lw=0.3)
+        median = np.median(d_clipped)
+        ax.axvline(median, color="black", ls="-", lw=0.8)
+        ax.axvline(clip99, color="gray", ls="--", lw=0.6)
+        ax.set_title(band, fontsize=6)
+        ax.tick_params(labelsize=4)
+        ax.set_xlabel("variance", fontsize=5)
     axes[0].set_ylabel("Count", fontsize=6)
-    fig.suptitle("Per-band LOO-ISC distributions", fontsize=8, y=1.02)
+    fig.suptitle("Per-band variance distributions", fontsize=8, y=1.02)
     fig.tight_layout()
     return fig
 
 
 def sketch_bar_grouped_bands() -> Figure:
     rng = np.random.default_rng(13)
-    bands = ["δ", "θ", "α", "β", "γ"]
+    bands = ["delta", "theta", "alpha", "beta", "gamma"]
     x = np.arange(len(bands))
     w = 0.35
     classic = rng.uniform(0.05, 0.3, len(bands))
@@ -346,10 +368,10 @@ def sketch_grid_timeseries_heatmap() -> Figure:
     rng = np.random.default_rng(14)
     fig, axes = plt.subplots(2, 2, figsize=(5.5, 3.2))
     titles = [
-        ("α Classic", "steelblue"),
-        ("α Psytrance", "darkorange"),
-        ("β Classic", "seagreen"),
-        ("β Psytrance", "tomato"),
+        ("alpha Classic", "steelblue"),
+        ("alpha Psytrance", "darkorange"),
+        ("beta Classic", "seagreen"),
+        ("beta Psytrance", "tomato"),
     ]
     n_w, n_ch = 40, 20
     for ax, (title, col) in zip(axes.flat, titles):
@@ -366,8 +388,8 @@ def sketch_grid_timeseries_heatmap() -> Figure:
 
 def sketch_raster_overlap() -> Figure:
     rng = np.random.default_rng(15)
-    bands = ["δ", "θ", "α", "β", "γ"]
-    colors = ["#4C72B0", "#55A868", "#C44E52", "#8172B2", "#CCB974"]
+    bands = ["delta", "theta", "alpha", "beta", "gamma"]
+    colors = ["steelblue", "darkorange", "seagreen", "tomato", "mediumpurple"]
     n_w = 60
     masks = (rng.uniform(0, 1, (5, n_w)) > 0.6).astype(float)
     fig, (ax_raster, ax_count) = plt.subplots(
@@ -430,6 +452,152 @@ def sketch_polar_histogram() -> Figure:
     return fig
 
 
+def sketch_zscore_transform() -> Figure:
+    """Before/after Z-score illustration."""
+    rng = np.random.default_rng(17)
+    fig, axes = plt.subplots(1, 2, figsize=(5.5, 2.5))
+    t = np.linspace(0, 4, 200)
+    amps = [0.5, 1.2, 2.0, 0.8]
+    offsets = [0.0, 1.0, -0.5, 1.5]
+    colors = ["steelblue", "darkorange", "seagreen", "tomato"]
+    # Left: raw (different amplitudes)
+    ax_raw = axes[0]
+    for amp, off, col in zip(amps, offsets, colors):
+        y = amp * np.sin(2 * np.pi * t) + off + rng.standard_normal(200) * 0.1
+        ax_raw.plot(t, y, lw=0.9, color=col, alpha=0.8)
+    ax_raw.set_title("Raw (unscaled)", fontsize=8)
+    ax_raw.set_xlabel("Time (s)", fontsize=7)
+    ax_raw.set_ylabel("Amplitude", fontsize=7)
+    ax_raw.tick_params(labelsize=6)
+    # Right: z-scored (normalized)
+    ax_z = axes[1]
+    for amp, off, col in zip(amps, offsets, colors):
+        y = amp * np.sin(2 * np.pi * t) + off + rng.standard_normal(200) * 0.1
+        y_z = (y - y.mean()) / y.std()
+        ax_z.plot(t, y_z, lw=0.9, color=col, alpha=0.8)
+    ax_z.set_title("Z-scored (mean=0, std=1)", fontsize=8)
+    ax_z.set_xlabel("Time (s)", fontsize=7)
+    ax_z.set_ylabel("Z-score", fontsize=7)
+    ax_z.axhline(0, color="gray", ls="--", lw=0.6)
+    ax_z.tick_params(labelsize=6)
+    fig.tight_layout()
+    return fig
+
+
+def sketch_timeseries_two_panel() -> Figure:
+    """Two-panel: top = mean signal overlay (blue), bottom = variance trace (orange)."""
+    rng = np.random.default_rng(18)
+    t = np.linspace(0, 10, 500)
+    n_subj = 6
+    group_mean = np.sin(0.5 * t) * 0.3 + rng.standard_normal(500) * 0.1
+    fig, (ax_top, ax_bot) = plt.subplots(
+        2, 1, figsize=(5, 3.2), sharex=True, gridspec_kw={"height_ratios": [1.2, 1]}
+    )
+    # Top: per-subject traces + group mean + ±1 SD band
+    sd = np.zeros(500)
+    for _ in range(n_subj):
+        y = group_mean + rng.standard_normal(500) * 0.25
+        ax_top.plot(t, y, lw=0.5, alpha=0.35, color="steelblue")
+        sd += (y - group_mean) ** 2
+    sd = np.sqrt(sd / n_subj)
+    ax_top.plot(t, group_mean, lw=1.2, color="steelblue", label="group mean")
+    ax_top.fill_between(
+        t, group_mean - sd, group_mean + sd, alpha=0.2, color="steelblue", label="±1 SD"
+    )
+    ax_top.set_ylabel("Mean signal", fontsize=7)
+    ax_top.legend(fontsize=6)
+    ax_top.tick_params(labelsize=6)
+    ax_top.set_title("Inter-subject time-series overview", fontsize=8)
+    # Bottom: channel-averaged variance
+    var_trace = np.abs(rng.standard_normal(500)) * 0.5 + 0.5
+    var_trace[100:150] *= 0.3
+    var_trace[330:380] *= 0.25
+    ax_bot.plot(t, var_trace, lw=0.8, color="darkorange")
+    ax_bot.set_xlabel("Time (s)", fontsize=7)
+    ax_bot.set_ylabel("Variance", fontsize=7)
+    ax_bot.tick_params(labelsize=6)
+    fig.tight_layout()
+    return fig
+
+
+def sketch_windowed_mean_var_bars() -> Figure:
+    """Two stacked bar charts: mean signal (blue) and variance (orange, green=sync)."""
+    rng = np.random.default_rng(19)
+    n_win = 20
+    x = np.arange(n_win)
+    mean_vals = rng.standard_normal(n_win) * 0.3
+    var_vals = np.abs(rng.standard_normal(n_win)) * 0.4 + 0.3
+    threshold = np.percentile(var_vals, 10)
+    sync_mask = var_vals < threshold
+    fig, (ax_top, ax_bot) = plt.subplots(2, 1, figsize=(5, 3), sharex=True)
+    # Top: mean signal per window (blue)
+    ax_top.bar(x, mean_vals, color="steelblue", width=0.8)
+    ax_top.axhline(0, color="gray", lw=0.6)
+    ax_top.set_ylabel("Mean signal", fontsize=7)
+    ax_top.tick_params(labelsize=6)
+    ax_top.set_title("Windowed synchrony — bar charts", fontsize=8)
+    # Bottom: variance per window (orange, green=sync)
+    bar_colors = ["seagreen" if s else "darkorange" for s in sync_mask]
+    ax_bot.bar(x, var_vals, color=bar_colors, width=0.8)
+    ax_bot.axhline(threshold, color="gray", ls="--", lw=0.8, label="10th pct")
+    ax_bot.set_xlabel("Window index", fontsize=7)
+    ax_bot.set_ylabel("Variance", fontsize=7)
+    ax_bot.legend(fontsize=6)
+    ax_bot.tick_params(labelsize=6)
+    fig.tight_layout()
+    return fig
+
+
+def sketch_windowed_overlay_panels() -> Figure:
+    """Three-panel windowed overlay: mean signal, variance+windowed line, channel heatmap."""
+    rng = np.random.default_rng(20)
+    t = np.linspace(0, 10, 500)
+    n_ch = 30
+    fig, axes = plt.subplots(
+        3, 1, figsize=(5, 4), gridspec_kw={"height_ratios": [1, 1, 1.5]}
+    )
+    # Panel 1: mean signal (blue) with per-subject traces
+    group_mean = np.sin(0.4 * t) * 0.3 + rng.standard_normal(500) * 0.1
+    for _ in range(4):
+        axes[0].plot(
+            t,
+            group_mean + rng.standard_normal(500) * 0.2,
+            lw=0.5,
+            alpha=0.3,
+            color="steelblue",
+        )
+    axes[0].plot(t, group_mean, lw=1.0, color="steelblue")
+    axes[0].set_ylabel("Mean signal", fontsize=7)
+    axes[0].tick_params(labelsize=5)
+    axes[0].set_title("Windowed overlay", fontsize=8)
+    # Panel 2: continuous variance (orange) + windowed mean line (red step)
+    var_cont = np.abs(rng.standard_normal(500)) * 0.4 + 0.5
+    n_win = 25
+    win_edges = np.linspace(0, len(t), n_win + 1, dtype=int)
+    win_means = [var_cont[win_edges[i] : win_edges[i + 1]].mean() for i in range(n_win)]
+    win_t = [
+        (t[win_edges[i]] + t[min(win_edges[i + 1], len(t) - 1)]) / 2
+        for i in range(n_win)
+    ]
+    axes[1].plot(t, var_cont, lw=0.8, color="darkorange")
+    axes[1].step(
+        win_t, win_means, where="mid", lw=1.2, color="tomato", label="windowed mean"
+    )
+    axes[1].set_ylabel("Variance", fontsize=7)
+    axes[1].legend(fontsize=5)
+    axes[1].tick_params(labelsize=5)
+    # Panel 3: heatmap (channels × time), reddish colormap, positive only
+    heatmap = np.abs(rng.standard_normal((n_ch, 500))) * 0.5 + 0.1
+    im = axes[2].imshow(heatmap, aspect="auto", cmap="Reds", vmin=0, vmax=1.5)
+    axes[2].set_ylabel("Channel", fontsize=7)
+    axes[2].set_xlabel("Time (s)", fontsize=7)
+    axes[2].tick_params(labelsize=5)
+    axes[2].set_xticks([])
+    plt.colorbar(im, ax=axes[2], fraction=0.03, pad=0.02)
+    fig.tight_layout()
+    return fig
+
+
 SKETCH_FUNCTIONS: dict[str, Callable[[], Figure]] = {
     "timeseries_multichannel": sketch_timeseries_multichannel,
     "psd": sketch_psd,
@@ -448,6 +616,11 @@ SKETCH_FUNCTIONS: dict[str, Callable[[], Figure]] = {
     "grid_timeseries_heatmap": sketch_grid_timeseries_heatmap,
     "raster_overlap": sketch_raster_overlap,
     "polar_histogram": sketch_polar_histogram,
+    # 01-mean-variance specific sketches
+    "zscore_transform": sketch_zscore_transform,
+    "timeseries_two_panel": sketch_timeseries_two_panel,
+    "windowed_mean_var_bars": sketch_windowed_mean_var_bars,
+    "windowed_overlay_panels": sketch_windowed_overlay_panels,
 }
 
 


### PR DESCRIPTION
## Summary

- Adds a new **Z-score rationale entry** (section 0) with a before/after sketch explaining why Z-scoring is applied before mean-variance analysis
- Fixes `timeseries_overview`: removes incorrect operation_order steps 1 & 2; new two-panel sketch (blue mean signal top, orange variance bottom)
- Fixes `variance_distribution`: orange histogram, 99th-percentile as right-boundary marker + median marker, updated interpretation noting channel × time variance distribution
- Fixes `windowed_bar`: corrected operation_order for blue mean / orange variance bar charts with green sync windows; new `windowed_mean_var_bars` sketch
- Fixes `windowed_overlay`: 3-panel operation_order (mean signal, variance + windowed mean line, reddish channel heatmap); new `windowed_overlay_panels` sketch
- Fixes `band_timeseries`: clarified operation_order, adds band color legend to interpretation
- Fixes `band_variance_distributions`: 99th-percentile as right boundary, updated interpretation
- Fixes `band_windowed_analysis`: full operation_order with panel descriptions matching task 5
- Replaces all Greek symbols (δ θ α β γ) with plain words in all sketch functions
- Aligns band colors across `timeseries_multiband`, `histogram_facet`, `raster_overlap`: delta=blue, theta=orange, alpha=green, beta=red, gamma=violet
- Updates `grid_timeseries_heatmap` to use plain band name words

## Test plan

- [x] Launch Streamlit catalog: `uv run --with "streamlit>=1.32.0" --with "pyyaml>=6.0" --with "numpy>=1.24.0" --with "matplotlib>=3.7.0" streamlit run viz_catalog/app.py`
- [ ] Navigate to **Stage 01 — Mean-Variance Synchrony** and verify all 8 plot cards render without warnings
- [ ] Confirm Z-score rationale card appears first with the before/after sketch
- [ ] Confirm `timeseries_overview` shows the two-panel blue/orange sketch
- [ ] Confirm `variance_distribution` shows orange histogram with 99th-pct and median markers
- [ ] Confirm `windowed_bar` shows two stacked bar charts (blue top, orange+green bottom)
- [ ] Confirm `windowed_overlay` shows 3-panel sketch with reddish heatmap
- [ ] Confirm per-band sketches use plain word band names and correct colors

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)